### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_FeatherWing.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_FeatherWing
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_FeatherWing.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_FeatherWing
     :alt: Build Status
 
 This library provides FeatherWing specific classes for those that require a significant amount of


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.