### PR TITLE
Adding class for TFT 2.4" FeatherWing

### DIFF
--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2019 Melissa LeBlanc-Williams, Foamyguy for Adafruit Industries LLC
+# Copyright (c) 2020 Melissa LeBlanc-Williams, Foamyguy for Adafruit Industries LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -1,0 +1,80 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 Melissa LeBlanc-Williams, Foamyguy for Adafruit Industries LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_featherwing.tft_featherwing_24`
+====================================================
+
+Helper for using the `TFT FeatherWing 2.4"`
+<https://www.adafruit.com/product/3315>`_.
+
+* Author(s): Melissa LeBlanc-Williams, Foamyguy
+
+Requires:
+* adafruit_ili9341
+* adafruit_stmpe610
+"""
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
+
+import board
+import digitalio
+import displayio
+import adafruit_ili9341
+from adafruit_stmpe610 import Adafruit_STMPE610_SPI
+import sdcardio
+import storage
+
+
+class TFTFeatherWing24:
+    """Class representing an `TFT FeatherWing 2.4
+       <https://www.adafruit.com/product/3315>`_.
+
+       """
+
+    def __init__(self, i2c=None, spi=None, cs=None, dc=None):
+        displayio.release_displays()
+        if i2c is None:
+            i2c = board.I2C()
+        if spi is None:
+            spi = board.SPI()
+        if cs is None:
+            cs = board.D9
+        if dc is None:
+            dc = board.D10
+
+        ts_cs = digitalio.DigitalInOut(board.D6)
+        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+
+        display_bus = displayio.FourWire(
+            spi, command=dc, chip_select=cs
+        )
+        self.display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
+
+        sd_cs = board.D5
+        self._sdcard = None
+        try:
+            self._sdcard = sdcardio.SDCard(spi, sd_cs)
+            vfs = storage.VfsFat(self._sdcard)
+            storage.mount(vfs, "/sd")
+        except OSError as error:
+            print("No SD card found:", error)

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -51,10 +51,8 @@ class TFTFeatherWing24:
 
        """
 
-    def __init__(self, i2c=None, spi=None, cs=None, dc=None):
+    def __init__(self, spi=None, cs=None, dc=None):
         displayio.release_displays()
-        if i2c is None:
-            i2c = board.I2C()
         if spi is None:
             spi = board.SPI()
         if cs is None:

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -44,7 +44,7 @@ from adafruit_stmpe610 import Adafruit_STMPE610_SPI
 import sdcardio
 import storage
 
-
+# pylint: disable-msg=too-few-public-methods
 class TFTFeatherWing24:
     """Class representing an `TFT FeatherWing 2.4
        <https://www.adafruit.com/product/3315>`_.
@@ -63,9 +63,7 @@ class TFTFeatherWing24:
         ts_cs = digitalio.DigitalInOut(board.D6)
         self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
 
-        display_bus = displayio.FourWire(
-            spi, command=dc, chip_select=cs
-        )
+        display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
         self.display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
 
         sd_cs = board.D5

--- a/examples/featherwing_tft24_simpletest.py
+++ b/examples/featherwing_tft24_simpletest.py
@@ -1,15 +1,25 @@
-import board
+"""
+This example will display a CircuitPython console and
+print the coordinates of touchscreen presses.
+
+It will also try to write and then read a file on the
+SD Card.
+"""
 from adafruit_featherwing import tft_featherwing_24
 
 tft_featherwing = tft_featherwing_24.TFTFeatherWing24()
 
-f = open("/sd/tft_featherwing.txt", "w")
-f.write("Blinka\nTFT 2.4\" FeatherWing")
-f.close()
+try:
+    f = open("/sd/tft_featherwing.txt", "w")
+    f.write("Blinka\nBlackberry Q10 Keyboard")
+    f.close()
 
-f = open("/sd/tft_featherwing.txt", "r")
-print(f.read())
-f.close()
+    f = open("/sd/tft_featherwing.txt", "r")
+    print(f.read())
+    f.close()
+except OSError as error:
+    print("Unable to write to SD Card.")
+
 
 while True:
     if not tft_featherwing.touchscreen.buffer_empty:

--- a/examples/featherwing_tft24_simpletest.py
+++ b/examples/featherwing_tft24_simpletest.py
@@ -1,0 +1,16 @@
+import board
+from adafruit_featherwing import tft_featherwing_24
+
+tft_featherwing = tft_featherwing_24.TFTFeatherWing24()
+
+f = open("/sd/tft_featherwing.txt", "w")
+f.write("Blinka\nTFT 2.4\" FeatherWing")
+f.close()
+
+f = open("/sd/tft_featherwing.txt", "r")
+print(f.read())
+f.close()
+
+while True:
+    if not tft_featherwing.touchscreen.buffer_empty:
+        print(tft_featherwing.touchscreen.read_data())


### PR DESCRIPTION
This adds a helper class for https://www.adafruit.com/product/3315.

All testing and development took place with TFT 2.4" FeatherWing and
```
Adafruit CircuitPython 6.0.0-alpha.3 on 2020-08-28; Adafruit Feather M4 Express with samd51j19
```