### PR TITLE
adding a helper class for keyboard featherwing

### DIFF
--- a/adafruit_featherwing/keyboard_featherwing.py
+++ b/adafruit_featherwing/keyboard_featherwing.py
@@ -1,0 +1,82 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Foamyguy for Adafruit Industries LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_featherwing.keyboard_featherwing`
+====================================================
+
+Helper for using the `Keyboard Featherwing`
+<https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/>`_.
+
+* Author(s): Foamyguy
+
+Requires:
+* adafruit_ili9341
+* adafruit_stmpe610
+"""
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
+
+import board
+import digitalio
+import displayio
+import adafruit_ili9341
+from adafruit_stmpe610 import Adafruit_STMPE610_SPI
+import sdcardio
+import storage
+from bbq10keyboard import BBQ10Keyboard, STATE_PRESS, STATE_RELEASE, STATE_LONG_PRESS
+import neopixel
+
+
+# pylint: disable-msg=too-few-public-methods
+class KeyboardFeatherwing:
+    """Class representing a `Keyboard Featherwing`
+       <https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/>`_.
+
+       """
+
+    def __init__(self, spi=None, cs=None, dc=None, i2c=None):
+        displayio.release_displays()
+        if spi is None:
+            spi = board.SPI()
+        if cs is None:
+            cs = board.D9
+        if dc is None:
+            dc = board.D10
+        if i2c is None:
+            i2c = board.I2C()
+
+        ts_cs = digitalio.DigitalInOut(board.D6)
+        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+
+        display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
+        self.display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
+        self.neopixel = neopixel.NeoPixel(board.D11, 1)
+        self.keyboard = BBQ10Keyboard(i2c)
+        sd_cs = board.D5
+        self._sdcard = None
+        try:
+            self._sdcard = sdcardio.SDCard(spi, sd_cs)
+            vfs = storage.VfsFat(self._sdcard)
+            storage.mount(vfs, "/sd")
+        except OSError as error:
+            print("No SD card found:", error)

--- a/adafruit_featherwing/keyboard_featherwing.py
+++ b/adafruit_featherwing/keyboard_featherwing.py
@@ -43,7 +43,7 @@ import adafruit_ili9341
 from adafruit_stmpe610 import Adafruit_STMPE610_SPI
 import sdcardio
 import storage
-from bbq10keyboard import BBQ10Keyboard, STATE_PRESS, STATE_RELEASE, STATE_LONG_PRESS
+from bbq10keyboard import BBQ10Keyboard
 import neopixel
 
 

--- a/examples/featherwing_keyboard_featherwing.py
+++ b/examples/featherwing_keyboard_featherwing.py
@@ -7,8 +7,8 @@ SD Card.
 It will also set the color of the neopixel on the featherwing.
 
 """
-from adafruit_featherwing import keyboard_featherwing
 from bbq10keyboard import STATE_RELEASE, STATE_LONG_PRESS
+from adafruit_featherwing import keyboard_featherwing
 
 kbd_featherwing = keyboard_featherwing.KeyboardFeatherwing()
 

--- a/examples/featherwing_keyboard_featherwing.py
+++ b/examples/featherwing_keyboard_featherwing.py
@@ -7,7 +7,7 @@ SD Card.
 
 """
 from adafruit_featherwing import keyboard_featherwing
-from bbq10keyboard import STATE_PRESS, STATE_RELEASE, STATE_LONG_PRESS
+from bbq10keyboard import STATE_RELEASE, STATE_LONG_PRESS
 
 kbd_featherwing = keyboard_featherwing.KeyboardFeatherwing()
 
@@ -35,9 +35,12 @@ while True:
     key_count = kbd_featherwing.keyboard.key_count
     if key_count > 0:
         key = kbd_featherwing.keyboard.key
-        state = 'pressed'
+        STATE = "pressed"
         if key[0] == STATE_LONG_PRESS:
-            state = 'held down'
+            STATE = "held down"
         elif key[0] == STATE_RELEASE:
-            state = 'released'
-        print("key: '%s' (dec %d, hex %02x) %s" % (key[1], ord(key[1]), ord(key[1]), state))
+            STATE = "released"
+        print(
+            "key: '%s' (dec %d, hex %02x) %s"
+            % (key[1], ord(key[1]), ord(key[1]), STATE)
+        )

--- a/examples/featherwing_keyboard_featherwing.py
+++ b/examples/featherwing_keyboard_featherwing.py
@@ -1,0 +1,43 @@
+"""
+This example will display a CircuitPython console and
+print the coordinates of touchscreen presses, as well
+as keyboard events from the BBQ10 keyboard.
+It will also try to write and then read a file on the
+SD Card.
+
+"""
+from adafruit_featherwing import keyboard_featherwing
+from bbq10keyboard import STATE_PRESS, STATE_RELEASE, STATE_LONG_PRESS
+
+kbd_featherwing = keyboard_featherwing.KeyboardFeatherwing()
+
+# set the neopixel on the kbd featherwing
+kbd_featherwing.neopixel.brightness = 0.1
+kbd_featherwing.neopixel[0] = 0x002244
+
+try:
+    f = open("/sd/tft_featherwing.txt", "w")
+    f.write("Blinka\nBlackberry Q10 Keyboard")
+    f.close()
+
+    f = open("/sd/tft_featherwing.txt", "r")
+    print(f.read())
+    f.close()
+except OSError as error:
+    print("Unable to write to SD Card.")
+
+while True:
+    # print touch info
+    if not kbd_featherwing.touchscreen.buffer_empty:
+        print(kbd_featherwing.touchscreen.read_data())
+
+    # print keyboard events
+    key_count = kbd_featherwing.keyboard.key_count
+    if key_count > 0:
+        key = kbd_featherwing.keyboard.key
+        state = 'pressed'
+        if key[0] == STATE_LONG_PRESS:
+            state = 'held down'
+        elif key[0] == STATE_RELEASE:
+            state = 'released'
+        print("key: '%s' (dec %d, hex %02x) %s" % (key[1], ord(key[1]), ord(key[1]), state))

--- a/examples/featherwing_keyboard_featherwing.py
+++ b/examples/featherwing_keyboard_featherwing.py
@@ -4,6 +4,7 @@ print the coordinates of touchscreen presses, as well
 as keyboard events from the BBQ10 keyboard.
 It will also try to write and then read a file on the
 SD Card.
+It will also set the color of the neopixel on the featherwing.
 
 """
 from adafruit_featherwing import keyboard_featherwing


### PR DESCRIPTION
Tested with Feather M4 + Keyboard Featherwing.

Since this is not a device that Adafruit sells I would understand if it should not get included in this repo. If that is the case I can make a seperate repo and submit it for the community bundle. 

Thanks to arturo182 for this great device!