### PR TITLE
pass additonal pins as arguments

### DIFF
--- a/adafruit_featherwing/keyboard_featherwing.py
+++ b/adafruit_featherwing/keyboard_featherwing.py
@@ -70,6 +70,8 @@ class KeyboardFeatherwing:
             spi = board.SPI()
         if cs is None:
             cs = board.D9
+        if dc is None:
+            dc = board.D10
         if i2c is None:
             i2c = board.I2C()
         if ts_cs is None:

--- a/adafruit_featherwing/keyboard_featherwing.py
+++ b/adafruit_featherwing/keyboard_featherwing.py
@@ -48,31 +48,43 @@ import neopixel
 
 
 # pylint: disable-msg=too-few-public-methods
+# pylint: disable-msg=too-many-arguments
 class KeyboardFeatherwing:
     """Class representing a `Keyboard Featherwing`
        <https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/>`_.
 
        """
 
-    def __init__(self, spi=None, cs=None, dc=None, i2c=None):
+    def __init__(
+        self,
+        spi=None,
+        cs=None,
+        dc=None,
+        i2c=None,
+        ts_cs=None,
+        sd_cs=None,
+        neopixel_pin=None,
+    ):
         displayio.release_displays()
         if spi is None:
             spi = board.SPI()
         if cs is None:
             cs = board.D9
-        if dc is None:
-            dc = board.D10
         if i2c is None:
             i2c = board.I2C()
+        if ts_cs is None:
+            ts_cs = board.D6
+        if sd_cs is None:
+            sd_cs = board.D5
+        if neopixel_pin is None:
+            neopixel_pin = board.D11
 
-        ts_cs = digitalio.DigitalInOut(board.D6)
-        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+        self.touchscreen = Adafruit_STMPE610_SPI(spi, digitalio.DigitalInOut(ts_cs))
 
         display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
         self.display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
-        self.neopixel = neopixel.NeoPixel(board.D11, 1)
+        self.neopixel = neopixel.NeoPixel(neopixel_pin, 1)
         self.keyboard = BBQ10Keyboard(i2c)
-        sd_cs = board.D5
         self._sdcard = None
         try:
             self._sdcard = sdcardio.SDCard(spi, sd_cs)


### PR DESCRIPTION
addresses #65 
add argument for passing ts_cs, sd_cs, neopixel_pin as arguments
keep defaults as expected.

tested default settings with feather_stm32f405_express
tested non-standard settings with umfeathers2

```
kbd_featherwing = keyboard_featherwing.KeyboardFeatherwing(cs=board.IO1,dc=board.IO3,ts_cs=boar>
          sd_cs=board.IO33,neopixel_pin=board.IO7)
```

I had to disable pylint (too-many-arguments)