### PR TITLE
Add tft 3.5 inch featherwing helper

### DIFF
--- a/adafruit_featherwing/auto_writeable.py
+++ b/adafruit_featherwing/auto_writeable.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_featherwing.auto_writeable`
+====================================================
+
+Superclass for the helpers pixelmatrix and matrix_featherwing
+
+* Author(s): Tim Cocks
+"""
+
+
+class AutoWriteable:
+    """Superclass for matrix_featherwing and pixelmatrix."""
+
+    def __init__(self):
+        self._auto_write = True
+
+    @property
+    def auto_write(self):
+        """
+        Whether or not we are automatically updating
+        If set to false, be sure to call show() to update
+        """
+        return self._auto_write
+
+    @auto_write.setter
+    def auto_write(self, write):
+        if isinstance(write, bool):
+            self._auto_write = write

--- a/adafruit_featherwing/matrix_featherwing.py
+++ b/adafruit_featherwing/matrix_featherwing.py
@@ -18,21 +18,24 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
 import board
 import adafruit_ht16k33.matrix as matrix
 
+from adafruit_featherwing.auto_writeable import AutoWriteable
 
-class MatrixFeatherWing:
+
+class MatrixFeatherWing(AutoWriteable):
     """Class representing an `Adafruit 8x16 LED Matrix FeatherWing
     <https://www.adafruit.com/product/3155>`_.
 
     Automatically uses the feather's I2C bus."""
 
     def __init__(self, address=0x70, i2c=None):
+
         if i2c is None:
             i2c = board.I2C()
         self._matrix = matrix.Matrix16x8(i2c, address)
         self._matrix.auto_write = False
         self.columns = 16
         self.rows = 8
-        self._auto_write = True
+        super().__init__()
 
     def __getitem__(self, key):
         """
@@ -124,19 +127,6 @@ class MatrixFeatherWing:
         """
         self._matrix.shift_down(rotate)
         self._update()
-
-    @property
-    def auto_write(self):
-        """
-        Whether or not we are automatically updating
-        If set to false, be sure to call show() to update
-        """
-        return self._auto_write
-
-    @auto_write.setter
-    def auto_write(self, write):
-        if isinstance(write, bool):
-            self._auto_write = write
 
     @property
     def blink_rate(self):

--- a/adafruit_featherwing/pixelmatrix.py
+++ b/adafruit_featherwing/pixelmatrix.py
@@ -16,9 +16,10 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
 
 # pylint: disable-msg=unsubscriptable-object, unsupported-assignment-operation
+from adafruit_featherwing.auto_writeable import AutoWriteable
 
 
-class PixelMatrix:
+class PixelMatrix(AutoWriteable):
     """Base Class for DotStar and NeoPixel FeatherWings
 
     The feather uses pins D13 and D11"""
@@ -27,7 +28,7 @@ class PixelMatrix:
         self.rows = 0
         self.columns = 0
         self._matrix = None
-        self._auto_write = True
+        super().__init__()
 
     def __setitem__(self, indices, value):
         """
@@ -157,19 +158,6 @@ class PixelMatrix:
                 ]
             self._matrix[(self.rows - 1) * self.columns + x] = last_pixel
         self._update()
-
-    @property
-    def auto_write(self):
-        """
-        Whether or not we are automatically updating
-        If set to false, be sure to call show() to update
-        """
-        return self._auto_write
-
-    @auto_write.setter
-    def auto_write(self, write):
-        if isinstance(write, bool):
-            self._auto_write = write
 
     @property
     def brightness(self):

--- a/adafruit_featherwing/rtc_featherwing.py
+++ b/adafruit_featherwing/rtc_featherwing.py
@@ -300,6 +300,7 @@ class RTCFeatherWing:
             return time.mktime(self._rtc.datetime)
         except (AttributeError, RuntimeError) as error:
             print("Error attempting to run time.mktime() on this board\n", error)
+            return None
 
     @unixtime.setter
     def unixtime(self, unixtime):

--- a/adafruit_featherwing/tft_featherwing.py
+++ b/adafruit_featherwing/tft_featherwing.py
@@ -22,14 +22,15 @@ from adafruit_stmpe610 import Adafruit_STMPE610_SPI
 import sdcardio
 import storage
 
-# pylint: disable-msg=too-few-public-methods
+
+# pylint: disable-msg=too-few-public-methods, too-many-arguments
 class TFTFeatherWing:
     """Class representing an `TFT FeatherWing 2.4
     <https://www.adafruit.com/product/3315>`_.
 
     """
 
-    def __init__(self, spi=None, cs=None, dc=None):
+    def __init__(self, spi=None, cs=None, dc=None, ts_cs=None, sd_cs=None):
         displayio.release_displays()
         if spi is None:
             spi = board.SPI()
@@ -38,12 +39,16 @@ class TFTFeatherWing:
         if dc is None:
             dc = board.D10
 
-        ts_cs = digitalio.DigitalInOut(board.D6)
+        if ts_cs is None:
+            ts_cs = board.D6
+        if sd_cs is None:
+            sd_cs = board.D5
+
+        ts_cs = digitalio.DigitalInOut(ts_cs)
         self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
 
         self._display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
 
-        sd_cs = board.D5
         self._sdcard = None
         try:
             self._sdcard = sdcardio.SDCard(spi, sd_cs)

--- a/adafruit_featherwing/tft_featherwing.py
+++ b/adafruit_featherwing/tft_featherwing.py
@@ -15,6 +15,7 @@ see tft_featherwng_24 and tft_featherwing_35
 Requires:
 * adafruit_stmpe610
 """
+import time
 import board
 import digitalio
 import displayio
@@ -45,7 +46,6 @@ class TFTFeatherWing:
             sd_cs = board.D5
 
         ts_cs = digitalio.DigitalInOut(ts_cs)
-        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
 
         self._display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
 
@@ -56,3 +56,12 @@ class TFTFeatherWing:
             storage.mount(vfs, "/sd")
         except OSError as error:
             print("No SD card found:", error)
+
+        try:
+            # the screen might not be ready from cold boot
+            time.sleep(0.8)
+            self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+        except RuntimeError:
+            # wait and try once more
+            time.sleep(1.0)
+            self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)

--- a/adafruit_featherwing/tft_featherwing.py
+++ b/adafruit_featherwing/tft_featherwing.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Foamyguy for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_featherwing.tft_featherwing`
+====================================================
+
+Super class for helpers for using the TFT FeatherWing devices
+see tft_featherwng_24 and tft_featherwing_35
+
+* Author(s): Melissa LeBlanc-Williams, Foamyguy
+
+Requires:
+* adafruit_stmpe610
+"""
+import board
+import digitalio
+import displayio
+from adafruit_stmpe610 import Adafruit_STMPE610_SPI
+import sdcardio
+import storage
+
+# pylint: disable-msg=too-few-public-methods
+class TFTFeatherWing:
+    """Class representing an `TFT FeatherWing 2.4
+    <https://www.adafruit.com/product/3315>`_.
+
+    """
+
+    def __init__(self, spi=None, cs=None, dc=None):
+        displayio.release_displays()
+        if spi is None:
+            spi = board.SPI()
+        if cs is None:
+            cs = board.D9
+        if dc is None:
+            dc = board.D10
+
+        ts_cs = digitalio.DigitalInOut(board.D6)
+        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+
+        self._display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
+
+        sd_cs = board.D5
+        self._sdcard = None
+        try:
+            self._sdcard = sdcardio.SDCard(spi, sd_cs)
+            vfs = storage.VfsFat(self._sdcard)
+            storage.mount(vfs, "/sd")
+        except OSError as error:
+            print("No SD card found:", error)

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -20,41 +20,21 @@ Requires:
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
 
-import board
-import digitalio
-import displayio
+
 import adafruit_ili9341
-from adafruit_stmpe610 import Adafruit_STMPE610_SPI
-import sdcardio
-import storage
 
 # pylint: disable-msg=too-few-public-methods
-class TFTFeatherWing24:
+from adafruit_featherwing.tft_featherwing import TFTFeatherWing
+
+
+class TFTFeatherWing24(TFTFeatherWing):
     """Class representing an `TFT FeatherWing 2.4
     <https://www.adafruit.com/product/3315>`_.
 
     """
 
     def __init__(self, spi=None, cs=None, dc=None):
-        displayio.release_displays()
-        if spi is None:
-            spi = board.SPI()
-        if cs is None:
-            cs = board.D9
-        if dc is None:
-            dc = board.D10
-
-        ts_cs = digitalio.DigitalInOut(board.D6)
-        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
-
-        display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
-        self.display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)
-
-        sd_cs = board.D5
-        self._sdcard = None
-        try:
-            self._sdcard = sdcardio.SDCard(spi, sd_cs)
-            vfs = storage.VfsFat(self._sdcard)
-            storage.mount(vfs, "/sd")
-        except OSError as error:
-            print("No SD card found:", error)
+        super().__init__(spi, cs, dc)
+        self.display = adafruit_ili9341.ILI9341(
+            self._display_bus, width=320, height=240
+        )

--- a/adafruit_featherwing/tft_featherwing_35.py
+++ b/adafruit_featherwing/tft_featherwing_35.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Foamyguy for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_featherwing.tft_featherwing_35`
+====================================================
+
+Helper for using the `TFT FeatherWing 3.5"`
+<https://www.adafruit.com/product/3651>`_.
+
+* Author(s): Melissa LeBlanc-Williams, Foamyguy
+
+Requires:
+* adafruit_hx8357
+* adafruit_stmpe610
+"""
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
+
+import board
+import digitalio
+import displayio
+from adafruit_hx8357 import HX8357
+from adafruit_stmpe610 import Adafruit_STMPE610_SPI
+import sdcardio
+import storage
+
+# pylint: disable-msg=too-few-public-methods
+class TFTFeatherWing35:
+    """Class representing an `TFT FeatherWing 3.5
+    <https://www.adafruit.com/product/3651>`_.
+
+    """
+
+    def __init__(self, spi=None, cs=None, dc=None):
+        displayio.release_displays()
+        if spi is None:
+            spi = board.SPI()
+        if cs is None:
+            cs = board.D9
+        if dc is None:
+            dc = board.D10
+
+        ts_cs = digitalio.DigitalInOut(board.D6)
+        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
+
+        display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
+        self.display = HX8357(display_bus, width=480, height=320)
+
+        sd_cs = board.D5
+        self._sdcard = None
+        try:
+            self._sdcard = sdcardio.SDCard(spi, sd_cs)
+            vfs = storage.VfsFat(self._sdcard)
+            storage.mount(vfs, "/sd")
+        except OSError as error:
+            print("No SD card found:", error)

--- a/adafruit_featherwing/tft_featherwing_35.py
+++ b/adafruit_featherwing/tft_featherwing_35.py
@@ -20,41 +20,18 @@ Requires:
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git"
 
-import board
-import digitalio
-import displayio
 from adafruit_hx8357 import HX8357
-from adafruit_stmpe610 import Adafruit_STMPE610_SPI
-import sdcardio
-import storage
 
 # pylint: disable-msg=too-few-public-methods
-class TFTFeatherWing35:
+from adafruit_featherwing.tft_featherwing import TFTFeatherWing
+
+
+class TFTFeatherWing35(TFTFeatherWing):
     """Class representing an `TFT FeatherWing 3.5
     <https://www.adafruit.com/product/3651>`_.
 
     """
 
     def __init__(self, spi=None, cs=None, dc=None):
-        displayio.release_displays()
-        if spi is None:
-            spi = board.SPI()
-        if cs is None:
-            cs = board.D9
-        if dc is None:
-            dc = board.D10
-
-        ts_cs = digitalio.DigitalInOut(board.D6)
-        self.touchscreen = Adafruit_STMPE610_SPI(spi, ts_cs)
-
-        display_bus = displayio.FourWire(spi, command=dc, chip_select=cs)
-        self.display = HX8357(display_bus, width=480, height=320)
-
-        sd_cs = board.D5
-        self._sdcard = None
-        try:
-            self._sdcard = sdcardio.SDCard(spi, sd_cs)
-            vfs = storage.VfsFat(self._sdcard)
-            storage.mount(vfs, "/sd")
-        except OSError as error:
-            print("No SD card found:", error)
+        super().__init__(spi, cs, dc)
+        self.display = HX8357(self._display_bus, width=480, height=320)

--- a/examples/featherwing_tft35_simpletest.py
+++ b/examples/featherwing_tft35_simpletest.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+This example will display a CircuitPython console and
+print the coordinates of touchscreen presses.
+
+It will also try to write and then read a file on the
+SD Card.
+"""
+from adafruit_featherwing import tft_featherwing_35
+
+tft_featherwing = tft_featherwing_35.TFTFeatherWing35()
+
+try:
+    f = open("/sd/tft_featherwing.txt", "w")
+    f.write("Blinka\nBlackberry Q10 Keyboard")
+    f.close()
+
+    f = open("/sd/tft_featherwing.txt", "r")
+    print(f.read())
+    f.close()
+except OSError as error:
+    print("Unable to write to SD Card.")
+
+
+while True:
+    if not tft_featherwing.touchscreen.buffer_empty:
+        print(tft_featherwing.touchscreen.read_data())


### PR DESCRIPTION
This adds a new helper class and example for the 3.5" Featherwing device. This can be used by the Touch Deck project code to remove the need for much of the display and touchscreen setup boilerplate code.

Unfortunately I don't think it is going to be passing actions currently. Due to code duplication

I refactored the existing tft_featherwing_24 class to use a new base class that it can share with the new tft_featherwing_35 added in this PR.

But there are still some duplicate sections between other previously existing helper classes for the keyboard_featherwing, as well as some for matrix_featherwing and pixelmatrix.

I tested these changes with a Feather RP2040 on the 3.5" and 2.4" Featherwings using the simpletest scripts and the current Touch Deck code: https://github.com/FoamyGuy/Touch_Deck_Working_Files