### PR TITLE
Add missing submodules to the docs

### DIFF
--- a/adafruit_featherwing/ina219_featherwing.py
+++ b/adafruit_featherwing/ina219_featherwing.py
@@ -8,6 +8,9 @@
 
 Helper for using the `INA219 FeatherWing <https://www.adafruit.com/product/3650>`_.
 
+.. image :: ../docs/_static/ina219_featherwing/ina219_featherwing.jpg
+  :alt: INA219 Featherwing
+
 * Author(s): Kattni Rembor
 """
 
@@ -39,9 +42,6 @@ class INA219FeatherWing:
     def bus_voltage(self):
         """Bus voltage returns volts.
 
-        .. image :: ../docs/_static/ina219_featherwing/ina219_featherwing.jpg
-          :alt: INA219 Featherwing
-
         This example prints the bus voltage with the appropriate units.
 
         .. code-block:: python
@@ -61,9 +61,6 @@ class INA219FeatherWing:
     @property
     def shunt_voltage(self):
         """Shunt voltage returns volts.
-
-        .. image :: ../docs/_static/ina219_featherwing/ina219_featherwing.jpg
-          :alt: INA219 Featherwing
 
         This example prints the shunt voltage with the appropriate units.
 
@@ -85,9 +82,6 @@ class INA219FeatherWing:
     def voltage(self):
         """Voltage, known as load voltage, is bus voltage plus shunt voltage. Returns volts.
 
-        .. image :: ../docs/_static/ina219_featherwing/ina219_featherwing.jpg
-          :alt: INA219 Featherwing
-
         This example prints the voltage with the appropriate units.
 
         .. code-block:: python
@@ -108,9 +102,6 @@ class INA219FeatherWing:
     @property
     def current(self):
         """Current returns mA.
-
-        .. image :: ../docs/_static/ina219_featherwing/ina219_featherwing.jpg
-          :alt: INA219 Featherwing
 
         This example prints the current with the appropriate units.
 

--- a/adafruit_featherwing/joy_featherwing.py
+++ b/adafruit_featherwing/joy_featherwing.py
@@ -173,9 +173,6 @@ class JoyFeatherWing:
     def joystick_offset(self):
         """Offset used to correctly report (0, 0) when the joystick is centered.
 
-        .. image :: ../docs/_static/joy_featherwing/joy_featherwing_joystick.jpg
-          :alt: Joy FeatherWing Joystick
-
         Provide a tuple of (x, y) to set your joystick center to (0, 0).
         The offset you provide is subtracted from the current reading.
         For example, if your joystick reads as (-4, 0), you would enter
@@ -214,9 +211,6 @@ class JoyFeatherWing:
         """Zeros the joystick by using current reading as (0, 0).
         Note: You must not be touching the joystick at the time of zeroing
         for it to be accurate.
-
-        .. image :: ../docs/_static/joy_featherwing/joy_featherwing_joystick.jpg
-          :alt: Joy FeatherWing Joystick
 
         This example zeros the joystick, and prints the coordinates of
         joystick when it is moved.

--- a/adafruit_featherwing/keyboard_featherwing.py
+++ b/adafruit_featherwing/keyboard_featherwing.py
@@ -6,7 +6,7 @@
 `adafruit_featherwing.keyboard_featherwing`
 ====================================================
 
-Helper for using the `Keyboard Featherwing`
+Helper for using the `Keyboard Featherwing
 <https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/>`_.
 
 * Author(s): Foamyguy
@@ -38,9 +38,8 @@ except ImportError:
 
 
 class KeyboardFeatherwing(TFTFeatherWing):
-    """Class representing a `Keyboard Featherwing`
+    """Class representing a `Keyboard Featherwing
     <https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/>`_.
-
     """
 
     def __init__(
@@ -64,4 +63,6 @@ class KeyboardFeatherwing(TFTFeatherWing):
             self._display_bus, width=320, height=240
         )
         self.neopixel = neopixel.NeoPixel(neopixel_pin, 1)
+        """Status NeoPixel."""
         self.keyboard = BBQ10Keyboard(i2c)
+        """BBQ10Keyboard instance."""

--- a/adafruit_featherwing/led_segments.py
+++ b/adafruit_featherwing/led_segments.py
@@ -6,7 +6,7 @@
 `adafruit_featherwing.led_segments`
 ====================================================
 
-Base Class for the AlphaNumeric FeatherWing and 7-Segment FeatherWing helpers_.
+Base Class for the AlphaNumeric FeatherWing and 7-Segment FeatherWing helpers.
 
 * Author(s): Melissa LeBlanc-Williams
 """
@@ -23,10 +23,7 @@ except ImportError:
 
 
 class Segments:
-    """Class representing an `Adafruit 14-segment AlphaNumeric FeatherWing
-    <https://www.adafruit.com/product/3139>`_.
-
-    Automatically uses the feather's I2C bus."""
+    """Base Class for the AlphaNumeric FeatherWing and 7-Segment FeatherWing helpers."""
 
     def __init__(self):
         self._segments = None

--- a/adafruit_featherwing/tft_featherwing.py
+++ b/adafruit_featherwing/tft_featherwing.py
@@ -33,10 +33,7 @@ except ImportError:
 
 # pylint: disable-msg=too-few-public-methods, too-many-arguments
 class TFTFeatherWing:
-    """Class representing an `TFT FeatherWing 2.4
-    <https://www.adafruit.com/product/3315>`_.
-
-    """
+    """Base class for TFT FeatherWings."""
 
     def __init__(
         self,
@@ -71,6 +68,8 @@ class TFTFeatherWing:
         except OSError as error:
             print("No SD card found:", error)
 
+        self.touchscreen = None
+        """Controller for the resistive touchscreen."""
         try:
             # the screen might not be ready from cold boot
             time.sleep(0.8)

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -7,7 +7,7 @@
 `adafruit_featherwing.tft_featherwing_24`
 ====================================================
 
-Helper for using the `TFT FeatherWing 2.4"`
+Helper for using the `TFT FeatherWing 2.4"
 <https://www.adafruit.com/product/3315>`_.
 
 * Author(s): Melissa LeBlanc-Williams, Foamyguy
@@ -35,7 +35,7 @@ except ImportError:
 class TFTFeatherWing24(TFTFeatherWing):
     """Class representing an `TFT FeatherWing 2.4
     <https://www.adafruit.com/product/3315>`_.
-
+    Attempts to mount the SD card to /sd.
     """
 
     def __init__(
@@ -50,3 +50,4 @@ class TFTFeatherWing24(TFTFeatherWing):
         self.display = adafruit_ili9341.ILI9341(
             self._display_bus, width=320, height=240
         )
+        """Display object for the FeatherWing's screen."""

--- a/adafruit_featherwing/tft_featherwing_35.py
+++ b/adafruit_featherwing/tft_featherwing_35.py
@@ -7,7 +7,7 @@
 `adafruit_featherwing.tft_featherwing_35`
 ====================================================
 
-Helper for using the `TFT FeatherWing 3.5"`
+Helper for using the `TFT FeatherWing 3.5"
 <https://www.adafruit.com/product/3651>`_.
 
 * Author(s): Melissa LeBlanc-Williams, Foamyguy
@@ -33,9 +33,9 @@ except ImportError:
 
 # pylint: disable-msg=too-few-public-methods, too-many-arguments
 class TFTFeatherWing35(TFTFeatherWing):
-    """Class representing an `TFT FeatherWing 3.5
+    """Class representing a `TFT FeatherWing 3.5
     <https://www.adafruit.com/product/3651>`_.
-
+    Attempts to mount the SD card to /sd.
     """
 
     def __init__(
@@ -48,3 +48,4 @@ class TFTFeatherWing35(TFTFeatherWing):
     ):
         super().__init__(spi, cs, dc, ts_cs, sd_cs)
         self.display = HX8357(self._display_bus, width=480, height=320)
+        """Display object for the FeatherWing's screen."""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,32 +1,51 @@
 
 .. If you created a package, create one automodule per module in the package.
 
-.. automodule:: adafruit_featherwing.ina219_featherwing
-   :members:
-
-.. automodule:: adafruit_featherwing.joy_featherwing
-   :members:
-
 .. automodule:: adafruit_featherwing.alphanum_featherwing
-   :members:
+    :inherited-members:
+    :members:
 
 .. automodule:: adafruit_featherwing.dotstar_featherwing
-   :members:
-
-.. automodule:: adafruit_featherwing.neopixel_featherwing
-   :members:
-
-.. automodule:: adafruit_featherwing.rtc_featherwing
-   :members:
+    :inherited-members:
+    :members:
 
 .. automodule:: adafruit_featherwing.gps_featherwing
-   :members:
+    :members:
+
+.. automodule:: adafruit_featherwing.ina219_featherwing
+    :members:
+
+.. automodule:: adafruit_featherwing.joy_featherwing
+    :members:
+
+.. automodule:: adafruit_featherwing.keyboard_featherwing
+    :inherited-members:
+    :members:
 
 .. automodule:: adafruit_featherwing.matrix_featherwing
-   :members:
+    :members:
 
 .. automodule:: adafruit_featherwing.minitft_featherwing
-  :members:
+    :members:
+
+.. automodule:: adafruit_featherwing.neopixel_featherwing
+    :inherited-members:
+    :members:
+
+.. automodule:: adafruit_featherwing.rtc_featherwing
+    :members:
+
+.. automodule:: adafruit_featherwing.sevensegment_featherwing
+    :inherited-members:
+    :members:
 
 .. automodule:: adafruit_featherwing.tempmotion_featherwing
-  :members:
+    :members:
+
+.. automodule:: adafruit_featherwing.tft_featherwing_24
+    :inherited-members:
+    :members:
+
+.. automodule:: adafruit_featherwing.tft_featherwing_35
+    :inherited-members:
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,13 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["board", "busio"]
+autodoc_mock_imports = [
+    "board",
+    "busio",
+    "bbq10keyboard",
+    "sdcardio",
+    "storage",
+]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
Add docstrings for properties.
Add inherited members to subclasses docs.
Add autodoc mock imports.
Fix product links.
Remove some repeated images.
Sorted the modules alphabetically in the docs page.