### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_featherwing/minitft_featherwing.py
+++ b/adafruit_featherwing/minitft_featherwing.py
@@ -63,8 +63,8 @@ class MiniTFTFeatherWing:
         address: int = 0x5E,
         i2c: Optional[I2C] = None,
         spi: Optional[SPI] = None,
-        cs: Optional[Pin] = None,
-        dc: Optional[Pin] = None,
+        cs: Optional[Pin] = None,  # pylint: disable=invalid-name
+        dc: Optional[Pin] = None,  # pylint: disable=invalid-name
     ):
         displayio.release_displays()
         if i2c is None:

--- a/adafruit_featherwing/tft_featherwing.py
+++ b/adafruit_featherwing/tft_featherwing.py
@@ -38,8 +38,8 @@ class TFTFeatherWing:
     def __init__(
         self,
         spi: Optional[SPI] = None,
-        cs: Optional[Pin] = None,
-        dc: Optional[Pin] = None,
+        cs: Optional[Pin] = None,  # pylint: disable=invalid-name
+        dc: Optional[Pin] = None,  # pylint: disable=invalid-name
         ts_cs: Optional[Pin] = None,
         sd_cs: Optional[Pin] = None,
     ):

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -41,8 +41,8 @@ class TFTFeatherWing24(TFTFeatherWing):
     def __init__(
         self,
         spi: Optional[SPI] = None,
-        cs: Optional[Pin] = None,
-        dc: Optional[Pin] = None,
+        cs: Optional[Pin] = None,  # pylint: disable=invalid-name
+        dc: Optional[Pin] = None,  # pylint: disable=invalid-name
         ts_cs: Optional[Pin] = None,
         sd_cs: Optional[Pin] = None,
     ):

--- a/adafruit_featherwing/tft_featherwing_24.py
+++ b/adafruit_featherwing/tft_featherwing_24.py
@@ -41,8 +41,8 @@ class TFTFeatherWing24(TFTFeatherWing):
     def __init__(
         self,
         spi: Optional[SPI] = None,
-        cs: Optional[Pin] = None,  # pylint: disable=invalid-name
-        dc: Optional[Pin] = None,  # pylint: disable=invalid-name
+        cs: Optional[Pin] = None,
+        dc: Optional[Pin] = None,
         ts_cs: Optional[Pin] = None,
         sd_cs: Optional[Pin] = None,
     ):


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
 ************* Module adafruit_featherwing.tft_featherwing
Error: adafruit_featherwing/tft_featherwing.py:41:8: C0103: Argument name "cs" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: adafruit_featherwing/tft_featherwing.py:42:8: C0103: Argument name "dc" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
************* Module adafruit_featherwing.minitft_featherwing
Error: adafruit_featherwing/minitft_featherwing.py:66:8: C0103: Argument name "cs" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: adafruit_featherwing/minitft_featherwing.py:67:8: C0103: Argument name "dc" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```